### PR TITLE
[TT-16951] feat: upgrade Go to 1.25 and add FIPS Docker image support

### DIFF
--- a/.container/image/bootstrap-post-fips/Dockerfile
+++ b/.container/image/bootstrap-post-fips/Dockerfile
@@ -1,0 +1,3 @@
+FROM tykio/dhi-busybox:1.37-fips
+
+ADD bootstrapapp-post /app/bin/bootstrap-app-post

--- a/.container/image/bootstrap-pre-delete-fips/Dockerfile
+++ b/.container/image/bootstrap-pre-delete-fips/Dockerfile
@@ -1,0 +1,3 @@
+FROM tykio/dhi-busybox:1.37-fips
+
+ADD bootstrapapp-pre-delete /app/bin/bootstrap-app-pre-delete

--- a/.container/image/bootstrap-pre-install-fips/Dockerfile
+++ b/.container/image/bootstrap-pre-install-fips/Dockerfile
@@ -1,0 +1,3 @@
+FROM tykio/dhi-busybox:1.37-fips
+
+ADD bootstrapapp-pre-install /app/bin/bootstrap-app-pre-install

--- a/.github/workflows/release_tag.yaml
+++ b/.github/workflows/release_tag.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.25.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,48 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -X main.version={{.Version}}
+  -
+    id: "post-fips"
+    main: ./cmd/bootstrap-post
+    binary: bootstrapapp-post
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+      - GOFIPS140=v1.0.0
+    ldflags:
+      - -X main.version={{.Version}}
+  -
+    id: "pre-fips"
+    main: ./cmd/bootstrap-pre-delete
+    binary: bootstrapapp-pre-delete
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+      - GOFIPS140=v1.0.0
+    ldflags:
+      - -X main.version={{.Version}}
+  -
+    id: "preinstall-fips"
+    main: ./cmd/bootstrap-pre-install
+    binary: bootstrapapp-pre-install
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+      - GOFIPS140=v1.0.0
+    ldflags:
+      - -X main.version={{.Version}}
 
 
 # https://goreleaser.com/customization/docker/
@@ -138,6 +180,85 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+  # FIPS docker images
+  -
+    ids:
+      - post-fips
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-post-fips:{{ .Tag }}-amd64"
+    goos: linux
+    goarch: amd64
+    dockerfile: ".container/image/bootstrap-post-fips/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  -
+    ids:
+      - post-fips
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+      - "tykio/tyk-k8s-bootstrap-post-fips:{{ .Tag }}-arm64v8"
+    goos: linux
+    goarch: arm64
+    dockerfile: ".container/image/bootstrap-post-fips/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+  -
+    ids:
+      - pre-fips
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:{{ .Tag }}-amd64"
+    goos: linux
+    goarch: amd64
+    dockerfile: ".container/image/bootstrap-pre-delete-fips/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  -
+    ids:
+      - pre-fips
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:{{ .Tag }}-arm64v8"
+    goos: linux
+    goarch: arm64
+    dockerfile: ".container/image/bootstrap-pre-delete-fips/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+  -
+    ids:
+      - preinstall-fips
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:{{ .Tag }}-amd64"
+    goos: linux
+    goarch: amd64
+    dockerfile: ".container/image/bootstrap-pre-install-fips/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  -
+    ids:
+      - preinstall-fips
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:{{ .Tag }}-arm64v8"
+    goos: linux
+    goarch: arm64
+    dockerfile: ".container/image/bootstrap-pre-install-fips/Dockerfile"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
 
 # https://goreleaser.com/customization/docker_manifest/
 docker_manifests:
@@ -200,3 +321,49 @@ docker_manifests:
     image_templates:
       - "tykio/tyk-k8s-bootstrap-pre-install:{{ .Tag }}-amd64"
       - "tykio/tyk-k8s-bootstrap-pre-install:{{ .Tag }}-arm64v8"
+
+  # FIPS docker manifests
+  - name_template: "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-post-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-post-fips:{{ .Tag }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-post-fips:{{ .Tag }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-post-fips:{{ .Tag }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-pre-delete-fips:{{ .Tag }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:{{ .Tag }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-delete-fips:{{ .Tag }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:v{{ .Major }}.{{ .Minor }}{{ if .Prerelease}}-{{ .Prerelease }}{{ end }}-arm64v8"
+
+  - name_template: "tykio/tyk-k8s-bootstrap-pre-install-fips:{{ .Tag }}"
+    image_templates:
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:{{ .Tag }}-amd64"
+      - "tykio/tyk-k8s-bootstrap-pre-install-fips:{{ .Tag }}-arm64v8"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tyk/tyk/bootstrap
 
-go 1.22.4
+go 1.25
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.22.4 to 1.25 in go.mod and release workflow
- Add FIPS Docker images using `tykio/dhi-busybox:1.37-fips` base image
- Add FIPS build entries to goreleaser with `GOFIPS140=v1.0.0`
- FIPS binaries built with `CGO_ENABLED=0 GOFIPS140=v1.0.0`

## New FIPS images
- `tykio/tyk-k8s-bootstrap-post-fips`
- `tykio/tyk-k8s-bootstrap-pre-delete-fips`
- `tykio/tyk-k8s-bootstrap-pre-install-fips`

## Changes
- `go.mod`: `go 1.22.4` -> `go 1.25`
- `.github/workflows/release_tag.yaml`: `go-version: 1.22.x` -> `go-version: 1.25.x`
- `.goreleaser.yaml`: Added 3 FIPS build entries, 6 FIPS docker entries (amd64+arm64), 9 FIPS docker manifest entries
- `.container/image/bootstrap-post-fips/Dockerfile`: New FIPS Dockerfile
- `.container/image/bootstrap-pre-delete-fips/Dockerfile`: New FIPS Dockerfile
- `.container/image/bootstrap-pre-install-fips/Dockerfile`: New FIPS Dockerfile

## Test plan
- [x] `go build ./...` passes with Go 1.25
- [ ] Standard images build correctly (no changes to existing Dockerfiles)
- [ ] FIPS images build correctly with goreleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)