### PR TITLE
[TT-16951] fix: goreleaser FIPS binary name collision

### DIFF
--- a/.container/image/bootstrap-post-fips/Dockerfile
+++ b/.container/image/bootstrap-post-fips/Dockerfile
@@ -1,3 +1,3 @@
 FROM tykio/dhi-busybox:1.37-fips
 
-ADD bootstrapapp-post /app/bin/bootstrap-app-post
+ADD bootstrapapp-post-fips /app/bin/bootstrap-app-post

--- a/.container/image/bootstrap-pre-delete-fips/Dockerfile
+++ b/.container/image/bootstrap-pre-delete-fips/Dockerfile
@@ -1,3 +1,3 @@
 FROM tykio/dhi-busybox:1.37-fips
 
-ADD bootstrapapp-pre-delete /app/bin/bootstrap-app-pre-delete
+ADD bootstrapapp-pre-delete-fips /app/bin/bootstrap-app-pre-delete

--- a/.container/image/bootstrap-pre-install-fips/Dockerfile
+++ b/.container/image/bootstrap-pre-install-fips/Dockerfile
@@ -1,3 +1,3 @@
 FROM tykio/dhi-busybox:1.37-fips
 
-ADD bootstrapapp-pre-install /app/bin/bootstrap-app-pre-install
+ADD bootstrapapp-pre-install-fips /app/bin/bootstrap-app-pre-install

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,7 @@ builds:
   -
     id: "post-fips"
     main: ./cmd/bootstrap-post
-    binary: bootstrapapp-post
+    binary: bootstrapapp-post-fips
     goos:
       - linux
     goarch:
@@ -67,7 +67,7 @@ builds:
   -
     id: "pre-fips"
     main: ./cmd/bootstrap-pre-delete
-    binary: bootstrapapp-pre-delete
+    binary: bootstrapapp-pre-delete-fips
     goos:
       - linux
     goarch:
@@ -81,7 +81,7 @@ builds:
   -
     id: "preinstall-fips"
     main: ./cmd/bootstrap-pre-install
-    binary: bootstrapapp-pre-install
+    binary: bootstrapapp-pre-install-fips
     goos:
       - linux
     goarch:


### PR DESCRIPTION
## Summary
Fix goreleaser build failure - FIPS and non-FIPS builds produced same binary name.

## Test plan
- [ ] goreleaser build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)