### PR TITLE
check HTTP response status when creating admin user

### DIFF
--- a/tyk/user.go
+++ b/tyk/user.go
@@ -108,7 +108,7 @@ func (s *Service) createAdmin() (NeededUserData, error) {
 		return NeededUserData{}, fmt.Errorf("user email already exists for this Org")
 	}
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode < 200 || res.StatusCode > 299 {
 		return NeededUserData{}, fmt.Errorf("create admin user failed with status %d: %s", res.StatusCode, string(bodyBytes))
 	}
 

--- a/tyk/user.go
+++ b/tyk/user.go
@@ -108,6 +108,10 @@ func (s *Service) createAdmin() (NeededUserData, error) {
 		return NeededUserData{}, fmt.Errorf("user email already exists for this Org")
 	}
 
+	if res.StatusCode != http.StatusOK {
+		return NeededUserData{}, fmt.Errorf("create admin user failed with status %d: %s", res.StatusCode, string(bodyBytes))
+	}
+
 	resp := api.CreateUserResp{}
 
 	err = json.Unmarshal(bodyBytes, &resp)


### PR DESCRIPTION
## Description
Return an error when admin user creation receives a non-2xx HTTP response from the Dashboard API. Previously, the bootstrap process silently ignored non-successful responses, which could lead to confusing downstream failures.

## Related Issue
[TT-17194](https://tyktech.atlassian.net/browse/TT-17194)

## Motivation and Context
`createAdmin()` in `tyk/user.go` did not check the HTTP response status from the Dashboard API. If the API returned an error (e.g., 500, 403), the code continued to unmarshal the response body, producing cryptic errors instead of a clear failure message.

## Test Coverage For This Change
Manually tested against a Dashboard instance returning non-2xx responses. The error message now includes the status code and response body for easier debugging.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] Pull request is against `main` from a topic branch
- [x] CHANGELOG.md updated (if applicable)
- [ ] Documentation updated (N/A)
- [ ] Tests added/updated
- [ ] All tests pass
- [ ] Linting passes (`gofmt`, `go vet`, `golangci-lint`)


[TT-17194]: https://tyktech.atlassian.net/browse/TT-17194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ